### PR TITLE
Add removal of cfengine_provisioner.rb to clean

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,6 +8,7 @@ clean:
 	-rm -rf tmp
 	-rm -rf masterfiles
 	-rm -rf masterfiles.before_gitify
+	-rm -rf cfengine_provisioner.rb
 
 ready:
 	mkdir -p tmp/seed


### PR DESCRIPTION
Oversight in first pull request. Sorry - Thomas
